### PR TITLE
feat - Create endpoints for user preferences management

### DIFF
--- a/apps/backend/src/app/users/dto/create-user-preference.dto.ts
+++ b/apps/backend/src/app/users/dto/create-user-preference.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsIn, IsNotEmpty } from 'class-validator';
+
+export class UserPreferenceDto {
+  @IsString()
+  @IsIn(['gender', 'theme', 'author'], {
+    message: 'preferencesKey must be one of the following values: gender, theme, author',
+  })
+  preferencesKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  preferencesValue: string;
+}

--- a/apps/backend/src/app/users/dto/create-user-preferences.dto.ts
+++ b/apps/backend/src/app/users/dto/create-user-preferences.dto.ts
@@ -1,0 +1,11 @@
+import { Type } from 'class-transformer';
+import { ValidateNested, ArrayNotEmpty, ArrayMinSize } from 'class-validator';
+import { UserPreferenceDto } from './create-user-preference.dto';
+
+export class CreateUserPreferencesDto {
+  @ValidateNested({ each: true })
+  @Type(() => UserPreferenceDto)
+  @ArrayNotEmpty()
+  @ArrayMinSize(1)
+  preferences: UserPreferenceDto[];
+}

--- a/apps/backend/src/app/users/dto/paginated-user-preference-res.dto.ts
+++ b/apps/backend/src/app/users/dto/paginated-user-preference-res.dto.ts
@@ -1,0 +1,7 @@
+import { PaginationResponseDto } from "../../common/dto/pagination-response.dto";
+import { UserPreference } from "../entities/user-preference.entity";
+
+
+export class PaginatedUserPreferenceResDto extends PaginationResponseDto {
+    preferences: UserPreference[];
+}

--- a/apps/backend/src/app/users/users.controller.ts
+++ b/apps/backend/src/app/users/users.controller.ts
@@ -16,6 +16,7 @@ import { AdminGuard } from '../auth/guards/admin.guard';
 import { CreateFavoriteBookDto } from './dto/create-favorite-book.dto';
 import { VerifySelfOrAdminGuard } from '../auth/guards/self-or-admin.guard';
 import { CreateReadingHistoryDto } from './dto/create-reading-history.dto';
+import { CreateUserPreferencesDto } from './dto/create-user-preferences.dto';
 
 @Controller('users')
 @UseGuards(AuthGuard)
@@ -84,5 +85,41 @@ export class UsersController {
   ) {
     await this.usersService.removeReadingHistory(userId, bookId);
     return { message: 'Reading history removed successfully' };
+  }
+
+  // User Preferences controllers
+  @Get(':userId/preferences')
+  @UseGuards(VerifySelfOrAdminGuard)
+  async getPreferences(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Query() paginationDto: PaginationDto
+  ) {
+    return this.usersService.getPreferences(userId, paginationDto);
+  }
+
+  @Post(':userId/preferences')
+  @UseGuards(VerifySelfOrAdminGuard)
+  async setPreferences(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Body() createUserPreferenceDto: CreateUserPreferencesDto,
+  ) {
+    return this.usersService.setPreferences(userId, createUserPreferenceDto);
+  }
+
+  @Delete(':userId/preferences/:preferencesId')
+  @UseGuards(VerifySelfOrAdminGuard)
+  async removePreference(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('preferencesId', ParseIntPipe) preferencesId: number
+  ) {
+    await this.usersService.removePreference(userId, preferencesId);
+    return { message: 'Preference removed successfully' };
+  }
+
+  @Delete(':userId/preferences')
+  @UseGuards(VerifySelfOrAdminGuard)
+  async resetPreferences(@Param('userId', ParseIntPipe) userId: number) {
+    await this.usersService.resetPreferences(userId);
+    return { message: 'Preferences reset successfully' };
   }
 }


### PR DESCRIPTION
# 📚 Implement Endpoints for User preferences Management

## 🛠️ Problem Description
The application currently lacks endpoints to manage user's preference. Additionally, there is a need to ensure only authorized users or admins can access and modify this information. 

## 🔧 Changes Proposed in this Release

### 🌐 New Endpoints

#### User Preference
- **Add User Preferences**:
  - **Endpoint**: `POST /users/:user_id/preferencess`
  - **Description**: Add preferences to the user's preference list
  - **Request Body**:
    ```json
       {
           "preferences": [
             {  
               "preferencesKey": "gender", "author", "theme"
               "preferencesValue": "string"
             }
          ]
       }
    ```

- **List user preferences**:
  - **Endpoint**: `GET /users/:user_id/preferences`
  - **Description**: Retrieves the list of the user's preference.

- **Delete user preference**:
  - **Endpoint**: `DELETE /users/:user_id/preferences/:preferences_id
  - **Description**: Removes a preference from the user's preference list.

## 🔍 Reviewers
@iGEVA

## 💬 Additional Comments
If there are any questions or additional feedback regarding these changes, please feel free to reach out.
